### PR TITLE
Add Dockerfile to run app in container. Resolves #3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM alpine/java:22-jdk
+
+WORKDIR /app
+
+COPY . /app
+
+WORKDIR /app/src
+
+# --- DEBUGGING STEP ---
+# This will list all files in the terminal so we can see the exact spelling/case
+RUN ls -la
+
+# Compile the code
+RUN javac -d . ToDoList.java
+
+# Run the app
+CMD ["java", "todolist.ToDoList"]


### PR DESCRIPTION
This Pull Request adds a `Dockerfile` to the root of the project, allowing users to build and run the To-Do list application inside an isolated Docker container. 

This resolves the feature request discussed in Issue #3.

## Docker file code
FROM alpine/java:22-jdk

WORKDIR /app

COPY . /app

WORKDIR /app/src

# This will list all files in the terminal so we can see the exact spelling/case
RUN ls -la

# Compile the code
RUN javac -d . ToDoList.java

# Run the app
CMD ["java", "todolist.ToDoList"]

To Build Docker Image
sudo docker build -t todo-list-app-java

To Run Docker container
sudo docker run -it todo-list-app-java
